### PR TITLE
Improve CSS accessibility

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -8,7 +8,27 @@
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             overflow-x: hidden;
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            color: #333;
+            color: #f0f0f0;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            line-height: 1.2;
+        }
+
+        h1 {
+            font-size: clamp(2rem, 4vw + 1rem, 3rem);
+        }
+
+        h2 {
+            font-size: clamp(1.5rem, 3vw + 0.8rem, 2.5rem);
+        }
+
+        h3 {
+            font-size: clamp(1.25rem, 2vw + 0.6rem, 2rem);
+        }
+
+        p {
+            font-size: clamp(1rem, 1vw + 0.4rem, 1.2rem);
         }
 
         /* Particles d'arrière-plan */
@@ -537,9 +557,9 @@
         
         /* Footer */
         .footer {
-            background: rgba(0, 0, 0, 0.2);
+            background: rgba(0, 0, 0, 0.4);
             padding: 3rem 0;
-            color: rgba(255, 255, 255, 0.8);
+            color: #ffffff;
         }
         
         .footer h5 {
@@ -568,7 +588,7 @@
         }
         
         .footer-links a {
-            color: rgba(255, 255, 255, 0.7);
+            color: #f0f0f0;
             text-decoration: none;
             transition: all 0.3s ease;
         }


### PR DESCRIPTION
## Summary
- improve contrast for body and footer text
- use `clamp()` for responsive heading and paragraph sizes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684423d7d1c88324b966b25514c5335c