### PR TITLE
Enhance navbar logo readability

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -71,6 +71,7 @@
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             animation: glow 2s ease-in-out infinite alternate;
+            text-shadow: 0 0 8px rgba(255, 255, 255, 0.8);
         }
 
         @keyframes glow {


### PR DESCRIPTION
## Summary
- add subtle glow to the `.logo` text so the "FicheNum" brand stands out over the transparent navbar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68444ec191a483248f09984c63079157