### PR TITLE
Add user registration with email verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ Then open `http://localhost:8000` in your browser to access FicheNum.
 - **Universal sharing** – each sheet comes with a QR code and a direct link ready to distribute.
 
 FicheNum aims to simplify content digestion for students, teachers and professionals alike. Feel free to adapt the code to your own needs.
+
+## User registration
+
+The `register.php` page lets visitors create an account. It checks whether the email already exists, stores a verification token and sends a confirmation link using PHP's `mail()` function. Following the link triggers `verify.php` which marks the user as verified.

--- a/register.php
+++ b/register.php
@@ -1,0 +1,84 @@
+<?php
+require_once 'config.php';
+
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+    $password = $_POST['password'] ?? '';
+
+    if (!$email || !$password) {
+        $message = "Email ou mot de passe invalide.";
+    } else {
+        // Vérifie si l'email existe déjà
+        $stmt = $pdo->prepare('SELECT id FROM users WHERE email = ?');
+        $stmt->execute([$email]);
+        if ($stmt->fetch()) {
+            $message = "Cette adresse email est déjà enregistrée.";
+        } else {
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $token = bin2hex(random_bytes(16));
+
+            $stmt = $pdo->prepare('INSERT INTO users (email, password, verify_token, verified) VALUES (?, ?, ?, 0)');
+            $stmt->execute([$email, $hash, $token]);
+
+            $verifyLink = 'http://' . $_SERVER['HTTP_HOST'] . '/verify.php?token=' . $token;
+            $subject = 'Confirmez votre inscription';
+            $body = "Bienvenue sur Fichesnum !\nCliquez sur ce lien pour vérifier votre adresse email : $verifyLink";
+            @mail($email, $subject, $body);
+
+            $message = "Inscription réussie. Vérifiez vos emails pour confirmer votre compte.";
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Inscription - Fichesnum</title>
+  <meta name="theme-color" content="#1a3c2c">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="assets/css/index.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark sticky-top">
+  <div class="container">
+    <a class="navbar-brand fw-bold d-flex align-items-center" href="/">
+      <i class="fas fa-book-open me-2"></i>Fichesnum
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainMenu">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="mainMenu">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="/">Accueil</a></li>
+      </ul>
+      <div class="ms-lg-3 mt-3 mt-lg-0">
+        <a href="/login.php" class="btn btn-sm btn-outline-light">Connexion</a>
+      </div>
+    </div>
+  </div>
+</nav>
+<div class="container py-5" style="max-width:600px;">
+  <h1 class="mb-4">Créer un compte</h1>
+  <?php if ($message): ?>
+    <div class="alert alert-info"><?= htmlspecialchars($message) ?></div>
+  <?php endif; ?>
+  <form method="post" novalidate>
+    <div class="mb-3">
+      <label for="email" class="form-label">Adresse email</label>
+      <input type="email" class="form-control" id="email" name="email" required>
+    </div>
+    <div class="mb-3">
+      <label for="password" class="form-label">Mot de passe</label>
+      <input type="password" class="form-control" id="password" name="password" required>
+    </div>
+    <button type="submit" class="btn btn-primary">S'inscrire</button>
+  </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/verify.php
+++ b/verify.php
@@ -1,0 +1,44 @@
+<?php
+require_once 'config.php';
+
+$message = 'Lien de vérification invalide.';
+
+$token = $_GET['token'] ?? '';
+if ($token) {
+    $stmt = $pdo->prepare('SELECT id FROM users WHERE verify_token = ? AND verified = 0');
+    $stmt->execute([$token]);
+    $user = $stmt->fetch();
+    if ($user) {
+        $stmt = $pdo->prepare('UPDATE users SET verified = 1, verify_token = NULL WHERE id = ?');
+        $stmt->execute([$user['id']]);
+        $message = 'Votre adresse email a été vérifiée avec succès.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Vérification - Fichesnum</title>
+  <meta name="theme-color" content="#1a3c2c">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="assets/css/index.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark sticky-top">
+  <div class="container">
+    <a class="navbar-brand fw-bold d-flex align-items-center" href="/">
+      <i class="fas fa-book-open me-2"></i>Fichesnum
+    </a>
+  </div>
+</nav>
+<div class="container py-5" style="max-width:600px;">
+  <h1 class="mb-4">Vérification de l'email</h1>
+  <div class="alert alert-info"><?= htmlspecialchars($message) ?></div>
+  <a href="/login.php" class="btn btn-primary">Se connecter</a>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement **register.php** for user registration
- send a verification link via PHP `mail()` and check for duplicate emails
- create **verify.php** to activate accounts
- document registration flow in README

## Testing
- `php -l register.php`
- `php -l verify.php`


------
https://chatgpt.com/codex/tasks/task_e_6845c0386764832483f41dca35f00bda