### PR TITLE
Add admin dashboard for admin role

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ FicheNum aims to simplify content digestion for students, teachers and professio
 ## User registration
 
 The `register.php` page lets visitors create an account. It checks whether the email already exists, stores a verification token and sends a confirmation link using PHP's `mail()` function. Following the link triggers `verify.php` which marks the user as verified.
+
+## Admin dashboard
+
+Users with the `admin` role can access `/admin/dashboard.php` after logging in. The navigation bar on the home page shows a Dashboard link for admins.

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,54 @@
+<?php
+session_start();
+require_once '../config.php';
+
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'admin') {
+    header('Location: /login.php');
+    exit;
+}
+
+// Example stats for dashboard
+try {
+    $stmt = $pdo->query('SELECT COUNT(*) FROM nfn_users');
+    $userCount = (int)$stmt->fetchColumn();
+} catch (Exception $e) {
+    $userCount = 0;
+}
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dashboard admin - Fichesnum</title>
+  <meta name="theme-color" content="#1a3c2c">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="/assets/css/index.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark sticky-top">
+  <div class="container">
+    <a class="navbar-brand fw-bold d-flex align-items-center" href="/">
+      <i class="fas fa-book-open me-2"></i>Fichesnum
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainMenu">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="mainMenu">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="/">Accueil</a></li>
+      </ul>
+      <div class="ms-lg-3 mt-3 mt-lg-0">
+        <a href="/logout.php" class="btn btn-sm btn-outline-light">Déconnexion</a>
+      </div>
+    </div>
+  </div>
+</nav>
+<div class="container py-5">
+  <h1 class="mb-4">Tableau de bord administrateur</h1>
+  <p class="lead">Utilisateurs enregistrés : <?= $userCount ?></p>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 $username = $_SESSION["username"] ?? null;
+$role = $_SESSION['role'] ?? null;
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -39,6 +40,9 @@ $username = $_SESSION["username"] ?? null;
         <div class="ms-lg-3 mt-3 mt-lg-0">
 <?php if ($username): ?>
           <span class="navbar-text me-3">Bonjour, <?= htmlspecialchars($username) ?></span>
+<?php if ($role === 'admin'): ?>
+          <a href="/admin/dashboard.php" class="btn btn-sm btn-warning me-2">Dashboard</a>
+<?php endif; ?>
           <a href="/logout.php" class="btn btn-sm btn-outline-light">Déconnexion</a>
 <?php else: ?>
           <a href="/login.php" class="btn btn-sm btn-outline-light">Connexion</a>

--- a/login.php
+++ b/login.php
@@ -10,12 +10,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!$email || !$password) {
         $message = "Email et mot de passe requis.";
     } else {
-        $stmt = $pdo->prepare('SELECT id, username, password FROM nfn_users WHERE email = ? AND verified = 1');
+        $stmt = $pdo->prepare('SELECT id, username, password, role FROM nfn_users WHERE email = ? AND verified = 1');
         $stmt->execute([$email]);
         $user = $stmt->fetch();
         if ($user && password_verify($password, $user['password'])) {
             $_SESSION['user_id'] = $user['id'];
             $_SESSION['username'] = $user['username'];
+            $_SESSION['role'] = $user['role'];
             header('Location: /index.php');
             exit;
         } else {

--- a/register.php
+++ b/register.php
@@ -22,8 +22,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $hash = password_hash($password, PASSWORD_DEFAULT);
             $token = bin2hex(random_bytes(16));
 
-            $stmt = $pdo->prepare('INSERT INTO nfn_users (email, password, username, verify_token, verified) VALUES (?, ?, ?, ?, 0)');
-            $stmt->execute([$email, $hash, $username, $token]);
+            $role = 'user';
+            $stmt = $pdo->prepare('INSERT INTO nfn_users (email, password, username, verify_token, verified, role) VALUES (?, ?, ?, ?, 0, ?)');
+            $stmt->execute([$email, $hash, $username, $token, $role]);
 
             $domain = $_SERVER['HTTP_HOST'];
             $verifyLink = 'http://' . $domain . '/verify.php?token=' . $token;

--- a/verify.php
+++ b/verify.php
@@ -5,11 +5,11 @@ $message = 'Lien de vérification invalide.';
 
 $token = $_GET['token'] ?? '';
 if ($token) {
-    $stmt = $pdo->prepare('SELECT id FROM users WHERE verify_token = ? AND verified = 0');
+    $stmt = $pdo->prepare('SELECT id FROM nfn_users WHERE verify_token = ? AND verified = 0');
     $stmt->execute([$token]);
     $user = $stmt->fetch();
     if ($user) {
-        $stmt = $pdo->prepare('UPDATE users SET verified = 1, verify_token = NULL WHERE id = ?');
+        $stmt = $pdo->prepare('UPDATE nfn_users SET verified = 1, verify_token = NULL WHERE id = ?');
         $stmt->execute([$user['id']]);
         $message = 'Votre adresse email a été vérifiée avec succès.';
     }


### PR DESCRIPTION
## Summary
- implement a basic admin dashboard
- persist user roles during registration and login
- restrict email verification to `nfn_users` table
- show the Dashboard link when logged as admin
- document admin access in README

## Testing
- `php` unavailable so no syntax checking

------
https://chatgpt.com/codex/tasks/task_e_6845d40aa5d88324a6ec65c5409b182c