### PR TITLE
Add fiche viewer with engagement stats

### DIFF
--- a/download_pdf.php
+++ b/download_pdf.php
@@ -1,0 +1,64 @@
+<?php
+require_once 'config.php';
+require_once 'Parsedown.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if (!$id) {
+    exit('ID manquant');
+}
+
+$stmt = $pdo->prepare('SELECT titre, fiche_text FROM nfn_fiches WHERE id = ?');
+$stmt->execute([$id]);
+$data = $stmt->fetch();
+if (!$data) {
+    exit('Fiche introuvable');
+}
+$pdo->prepare('UPDATE nfn_fiches SET downloads = downloads + 1 WHERE id = ?')->execute([$id]);
+
+$parsedown = new Parsedown();
+$parsedown->setSafeMode(true);
+$text = strip_tags($parsedown->text($data['fiche_text']));
+$title = $data['titre'];
+
+header('Content-Type: application/pdf');
+header('Content-Disposition: attachment; filename="'.preg_replace("/[^a-zA-Z0-9_-]/", "_", $title).'.pdf"');
+
+echo generateSimplePdf($title, $text);
+exit;
+
+function pdfEscape($string) {
+    return str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $string);
+}
+
+function generateSimplePdf($title, $text) {
+    $eol = "\n";
+    $parts = [];
+    $parts[1] = "<< /Type /Catalog /Pages 2 0 R >>";
+    $parts[2] = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>";
+    $parts[3] = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>";
+    $content = 'BT /F1 16 Tf 50 750 Td (' . pdfEscape($title) . ') Tj';
+    $y = 720;
+    foreach (explode("\n", $text) as $line) {
+        $content .= " 50 $y Td (" . pdfEscape(trim($line)) . ") Tj";
+        $y -= 14;
+    }
+    $content .= ' ET';
+    $parts[4] = "<< /Length " . strlen($content) . " >>" . $eol . "stream" . $eol . $content . $eol . "endstream";
+    $parts[5] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+    $pdf = "%PDF-1.4$eol";
+    $offsets = [];
+    $pos = strlen($pdf);
+    for ($i = 1; $i <= 5; $i++) {
+        $offsets[$i] = $pos;
+        $pdf .= "$i 0 obj$eol" . $parts[$i] . "$eol" . "endobj$eol";
+        $pos = strlen($pdf);
+    }
+    $xref = $pos;
+    $pdf .= "xref$eol0 6$eol0000000000 65535 f $eol";
+    for ($i = 1; $i <= 5; $i++) {
+        $pdf .= sprintf('%010d 00000 n ', $offsets[$i]) . $eol;
+    }
+    $pdf .= "trailer$eol<< /Size 6 /Root 1 0 R >>$eolstartxref$eol$xref$eol%%EOF";
+    return $pdf;
+}

--- a/fiche.php
+++ b/fiche.php
@@ -1,0 +1,99 @@
+<?php
+session_start();
+require_once 'config.php';
+require_once 'Parsedown.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if (!$id) {
+    header('Location: /index.php');
+    exit;
+}
+
+$parsedown = new Parsedown();
+$parsedown->setSafeMode(true);
+
+$stmt = $pdo->prepare('SELECT id, titre, categorie, fiche_text, views, likes, shares, downloads FROM nfn_fiches WHERE id = ?');
+$stmt->execute([$id]);
+$fiche = $stmt->fetch();
+if (!$fiche) {
+    http_response_code(404);
+    echo 'Fiche introuvable';
+    exit;
+}
+
+$pdo->prepare('UPDATE nfn_fiches SET views = views + 1 WHERE id = ?')->execute([$id]);
+$fiche['views']++;
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title><?= htmlspecialchars($fiche['titre']) ?> - Fichesnum</title>
+  <meta name="theme-color" content="#1a3c2c">
+  <link rel="icon" href="/assets/images/icon-512.png">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="assets/css/index.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark sticky-top">
+  <div class="container">
+    <a class="navbar-brand fw-bold d-flex align-items-center" href="/">
+      <img src="/assets/images/icon-512.png" alt="Fichesnum" class="logo me-2">Fichesnum
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainMenu">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="mainMenu">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="/dashboard.php">Mes fiches</a></li>
+      </ul>
+      <div class="ms-lg-3 mt-3 mt-lg-0">
+        <a href="/logout.php" class="btn btn-sm btn-outline-light">Déconnexion</a>
+      </div>
+    </div>
+  </div>
+</nav>
+
+<div class="container py-5" style="max-width:800px;">
+  <h1 class="mb-2"><?= htmlspecialchars($fiche['titre']) ?></h1>
+  <p class="text-muted">Catégorie : <?= htmlspecialchars($fiche['categorie']) ?></p>
+  <div class="ebook-content fiche-content mb-4">
+    <?= $parsedown->text($fiche['fiche_text']) ?>
+  </div>
+
+  <div class="d-flex flex-wrap gap-2 align-items-center mb-4">
+    <button id="like-btn" class="btn btn-sm btn-outline-primary">
+      <i class="fas fa-thumbs-up me-1"></i><span id="like-count"><?= (int)$fiche['likes'] ?></span>
+    </button>
+    <button id="share-btn" class="btn btn-sm btn-outline-secondary">
+      <i class="fas fa-share me-1"></i><span id="share-count"><?= (int)$fiche['shares'] ?></span>
+    </button>
+    <a id="download-btn" href="download_pdf.php?id=<?= $fiche['id'] ?>" class="btn btn-sm btn-outline-success">
+      <i class="fas fa-file-pdf me-1"></i>Télécharger (<span id="download-count"><?= (int)$fiche['downloads'] ?></span>)
+    </a>
+    <div class="ms-auto text-muted">
+      <i class="fas fa-eye me-1"></i><span id="view-count"><?= (int)$fiche['views'] ?></span>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+document.getElementById('like-btn').addEventListener('click', () => {
+  fetch('like.php?id=<?= $fiche['id'] ?>')
+    .then(r => r.json())
+    .then(data => { if(data.success) document.getElementById('like-count').textContent = data.likes; });
+});
+
+document.getElementById('share-btn').addEventListener('click', () => {
+  navigator.clipboard.writeText(window.location.href).then(() => {
+    fetch('share.php?id=<?= $fiche['id'] ?>')
+      .then(r => r.json())
+      .then(data => { if(data.success) document.getElementById('share-count').textContent = data.shares; });
+  });
+});
+</script>
+</body>
+</html>

--- a/like.php
+++ b/like.php
@@ -1,0 +1,13 @@
+<?php
+require_once 'config.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+header('Content-Type: application/json');
+if (!$id) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+$pdo->prepare('UPDATE nfn_fiches SET likes = likes + 1 WHERE id = ?')->execute([$id]);
+$stmt = $pdo->prepare('SELECT likes FROM nfn_fiches WHERE id = ?');
+$stmt->execute([$id]);
+$likes = (int)$stmt->fetchColumn();
+echo json_encode(['success' => true, 'likes' => $likes]);

--- a/share.php
+++ b/share.php
@@ -1,0 +1,13 @@
+<?php
+require_once 'config.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+header('Content-Type: application/json');
+if (!$id) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+$pdo->prepare('UPDATE nfn_fiches SET shares = shares + 1 WHERE id = ?')->execute([$id]);
+$stmt = $pdo->prepare('SELECT shares FROM nfn_fiches WHERE id = ?');
+$stmt->execute([$id]);
+$shares = (int)$stmt->fetchColumn();
+echo json_encode(['success' => true, 'shares' => $shares]);


### PR DESCRIPTION
## Summary
- add `fiche.php` to display a fiche with view/like/share/download counters
- add endpoints for liking and sharing a fiche
- allow PDF download with a simple in-house generator

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847329775148324bdeb42acfe9603af