### PR TITLE
Add like tracking with user check

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,16 @@ The `register.php` page lets visitors create an account. It checks whether the e
 ## Admin dashboard
 
 Users with the `admin` role can access `/admin/dashboard.php` after logging in. The navigation bar on the home page shows a Dashboard link for admins.
+
+## Likes tracking
+
+Likes are stored in a dedicated table to prevent duplicates. Create the table
+with the SQL script located at `sql/nfn_fiche_likes.sql`:
+
+```sql
+CREATE TABLE nfn_fiche_likes (
+  user_id INT NOT NULL,
+  fiche_id INT NOT NULL,
+  PRIMARY KEY(user_id, fiche_id)
+);
+```

--- a/like.php
+++ b/like.php
@@ -1,12 +1,38 @@
 <?php
+session_start();
 require_once 'config.php';
+
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 header('Content-Type: application/json');
+
 if (!$id) {
     echo json_encode(['success' => false]);
     exit;
 }
-$pdo->prepare('UPDATE nfn_fiches SET likes = likes + 1 WHERE id = ?')->execute([$id]);
+
+if (!isset($_SESSION['user_id'])) {
+    echo json_encode(['success' => false, 'error' => 'not_logged_in']);
+    exit;
+}
+
+$userId = (int)$_SESSION['user_id'];
+
+// Check if the user already liked this fiche
+$stmt = $pdo->prepare('SELECT 1 FROM nfn_fiche_likes WHERE user_id = ? AND fiche_id = ?');
+$stmt->execute([$userId, $id]);
+if ($stmt->fetch()) {
+    $stmt = $pdo->prepare('SELECT likes FROM nfn_fiches WHERE id = ?');
+    $stmt->execute([$id]);
+    $likes = (int)$stmt->fetchColumn();
+    echo json_encode(['success' => true, 'likes' => $likes]);
+    exit;
+}
+
+// Record the like and increment the count
+$pdo->prepare('INSERT INTO nfn_fiche_likes (user_id, fiche_id) VALUES (?, ?)')
+    ->execute([$userId, $id]);
+$pdo->prepare('UPDATE nfn_fiches SET likes = likes + 1 WHERE id = ?')
+    ->execute([$id]);
 $stmt = $pdo->prepare('SELECT likes FROM nfn_fiches WHERE id = ?');
 $stmt->execute([$id]);
 $likes = (int)$stmt->fetchColumn();

--- a/sql/nfn_fiche_likes.sql
+++ b/sql/nfn_fiche_likes.sql
@@ -1,0 +1,5 @@
+CREATE TABLE nfn_fiche_likes (
+  user_id INT NOT NULL,
+  fiche_id INT NOT NULL,
+  PRIMARY KEY(user_id, fiche_id)
+);


### PR DESCRIPTION
## Summary
- record likes per user in `nfn_fiche_likes` table
- prevent duplicate likes in `like.php`
- document likes table in README

## Testing
- `php -l like.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684737eac3708324931764ee5f673d55