### PR TITLE
Enhance share button with Web Share API

### DIFF
--- a/fiche.php
+++ b/fiche.php
@@ -88,11 +88,24 @@ document.getElementById('like-btn').addEventListener('click', () => {
 });
 
 document.getElementById('share-btn').addEventListener('click', () => {
-  navigator.clipboard.writeText(window.location.href).then(() => {
-    fetch('share.php?id=<?= $fiche['id'] ?>')
-      .then(r => r.json())
-      .then(data => { if(data.success) document.getElementById('share-count').textContent = data.shares; });
-  });
+  const url = window.location.href;
+  if (navigator.share) {
+    navigator.share({ url })
+      .then(() => {
+        fetch('share.php?id=<?= $fiche['id'] ?>')
+          .then(r => r.json())
+          .then(data => { if(data.success) document.getElementById('share-count').textContent = data.shares; });
+      })
+      .catch(() => alert('Échec du partage.'));
+  } else {
+    navigator.clipboard.writeText(url)
+      .then(() => {
+        fetch('share.php?id=<?= $fiche['id'] ?>')
+          .then(r => r.json())
+          .then(data => { if(data.success) document.getElementById('share-count').textContent = data.shares; });
+      })
+      .catch(() => alert('Impossible de copier le lien.'));
+  }
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- improve the share button in `fiche.php`
  - use `navigator.share` when available
  - fall back to clipboard sharing
  - show alerts when sharing/copying fails

## Testing
- `npm test` *(fails: package.json missing)*
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684738be9d8c8324b119743abfda8b4c