### PR TITLE
Add plan choice during sign up

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ FicheNum aims to simplify content digestion for students, teachers and professio
 
 The `register.php` page lets visitors create an account. It checks whether the email already exists, stores a verification token and sends a confirmation link using PHP's `mail()` function. Following the link triggers `verify.php` which marks the user as verified.
 
+During registration users can now choose between a **free** or **premium** plan. The selected plan is saved in the new `plan` column of the `nfn_users` table. Apply the SQL script `sql/add_plan_to_nfn_users.sql` to add this column if upgrading from an earlier version.
+
 ## Admin dashboard
 
 Users with the `admin` role can access `/admin/dashboard.php` after logging in. The navigation bar on the home page shows a Dashboard link for admins.

--- a/index.php
+++ b/index.php
@@ -2,6 +2,7 @@
 session_start();
 $username = $_SESSION["username"] ?? null;
 $role = $_SESSION['role'] ?? null;
+$plan = $_SESSION['plan'] ?? null;
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -64,6 +65,9 @@ $role = $_SESSION['role'] ?? null;
         <h1>Fiches IA. Mobile. Durable.</h1>
 <?php if ($username): ?>
           <p class="lead">Bienvenue, <?= htmlspecialchars($username) ?>.</p>
+          <?php if ($plan): ?>
+          <p class="text-muted">Formule : <?= htmlspecialchars($plan) ?></p>
+          <?php endif; ?>
 <?php endif; ?>
         <p>Générez vos fiches pédagogiques où que vous soyez, sans gaspiller d'énergie ni compromettre la qualité.</p>
         <div class="d-flex flex-wrap justify-content-center gap-3 mt-4">

--- a/login.php
+++ b/login.php
@@ -10,13 +10,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!$email || !$password) {
         $message = "Email et mot de passe requis.";
     } else {
-        $stmt = $pdo->prepare('SELECT id, username, password, role FROM nfn_users WHERE email = ? AND verified = 1');
+        $stmt = $pdo->prepare('SELECT id, username, password, role, plan FROM nfn_users WHERE email = ? AND verified = 1');
         $stmt->execute([$email]);
         $user = $stmt->fetch();
         if ($user && password_verify($password, $user['password'])) {
             $_SESSION['user_id'] = $user['id'];
             $_SESSION['username'] = $user['username'];
             $_SESSION['role'] = $user['role'];
+            $_SESSION['plan'] = $user['plan'];
             header('Location: /index.php');
             exit;
         } else {

--- a/register.php
+++ b/register.php
@@ -7,7 +7,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
     $username = trim($_POST['username'] ?? '');
     $password = $_POST['password'] ?? '';
-    $confirm = $_POST['confirm'] ?? '';
+    $confirm  = $_POST['confirm'] ?? '';
+    $plan     = $_POST['plan'] ?? 'free';
+    $plan     = ($plan === 'premium') ? 'premium' : 'free';
 
     if (!$email || !$username || !$password || !$confirm) {
         $message = "Tous les champs sont obligatoires.";
@@ -23,8 +25,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $token = bin2hex(random_bytes(16));
 
             $role = 'user';
-            $stmt = $pdo->prepare('INSERT INTO nfn_users (email, password, username, verify_token, verified, role) VALUES (?, ?, ?, ?, 0, ?)');
-            $stmt->execute([$email, $hash, $username, $token, $role]);
+            $stmt = $pdo->prepare('INSERT INTO nfn_users (email, password, username, verify_token, verified, role, plan) VALUES (?, ?, ?, ?, 0, ?, ?)');
+            $stmt->execute([$email, $hash, $username, $token, $role, $plan]);
 
             $domain = $_SERVER['HTTP_HOST'];
             $verifyLink = 'http://' . $domain . '/verify.php?token=' . $token;
@@ -109,6 +111,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       <span class="position-absolute top-50 end-0 translate-middle-y me-3" onclick="togglePassword('confirm')">
         <i class="fas fa-eye-slash" id="eye-confirm"></i>
       </span>
+    </div>
+    <div class="mb-3">
+      <label class="form-label d-block">Formule</label>
+      <div class="form-check form-check-inline">
+        <input class="form-check-input" type="radio" name="plan" id="plan-free" value="free" checked>
+        <label class="form-check-label" for="plan-free">Gratuite</label>
+      </div>
+      <div class="form-check form-check-inline">
+        <input class="form-check-input" type="radio" name="plan" id="plan-premium" value="premium">
+        <label class="form-check-label" for="plan-premium">Payante</label>
+      </div>
     </div>
     <button type="submit" class="btn btn-primary">S'inscrire</button>
   </form>

--- a/sql/add_plan_to_nfn_users.sql
+++ b/sql/add_plan_to_nfn_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE nfn_users ADD COLUMN plan ENUM('free','premium') NOT NULL DEFAULT 'free';


### PR DESCRIPTION
## Summary
- let users choose between free/premium plans on registration
- store the chosen plan in `nfn_users.plan`
- expose the plan in the session and home page
- document the new column and SQL script

## Testing
- `php -l register.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847534cb8c48324a6c746898fbf61c4