### PR TITLE
Improve registration plan cards

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -291,17 +291,25 @@
 }
 
 .plan-card {
+  background: #fff;
   border: 1px solid var(--neutral-300);
-  border-radius: 8px;
-  padding: 1rem;
+  border-radius: 12px;
   cursor: pointer;
-  transition: background-color 0.3s, border-color 0.3s, box-shadow 0.3s;
+  transition: transform 0.3s, box-shadow 0.3s, border-color 0.3s;
+}
+
+.plan-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 16px rgba(0,0,0,0.08);
+}
+
+.plan-card .plan-price {
+  color: var(--primary-700);
 }
 
 .plan-card.active {
   border-color: var(--primary-500);
-  background-color: var(--primary-50);
-  box-shadow: 0 0 8px rgba(0,0,0,0.1);
+  box-shadow: 0 0 0 3px var(--primary-100);
 }
     /* Contraste vérifié */
     /* Toutes les combinaisons texte/fond respectent WCAG AA au minimum */

--- a/register.php
+++ b/register.php
@@ -94,13 +94,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <?php endif; ?>
 
   <div class="d-flex gap-3 mb-4">
-    <div class="plan-card flex-fill" data-plan="free">
-      <h2 class="h5 mb-1">Formule gratuite</h2>
-      <p class="mb-0">Profitez des fonctionnalités de base.</p>
+    <div class="plan-card card flex-fill text-center" data-plan="free">
+      <div class="card-body">
+        <div class="text-primary mb-2">
+          <i class="fas fa-gift fa-2x" aria-hidden="true"></i>
+        </div>
+        <h2 class="card-title h5 mb-1">Formule gratuite</h2>
+        <p class="plan-price h4 fw-bold mb-1">0&nbsp;&euro;</p>
+        <p class="card-text small text-muted mb-0">Profitez des fonctionnalités de base.</p>
+      </div>
     </div>
-    <div class="plan-card flex-fill" data-plan="premium">
-      <h2 class="h5 mb-1">Formule premium</h2>
-      <p class="mb-0">Toutes les options pour 4,90&nbsp;&euro;.</p>
+    <div class="plan-card card flex-fill text-center" data-plan="premium">
+      <div class="card-body">
+        <div class="text-warning mb-2">
+          <i class="fas fa-crown fa-2x" aria-hidden="true"></i>
+        </div>
+        <h2 class="card-title h5 mb-1">Formule premium</h2>
+        <p class="plan-price h4 fw-bold mb-1">4,90&nbsp;&euro;</p>
+        <p class="card-text small text-muted mb-0">Toutes les options avancées.</p>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- make plan cards look more professional
- style plan cards with hover effect and new price styling

## Testing
- `php -l register.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684869c6cb9c8324b3781075109c747c