### PR TITLE
Limit fiche categories to one word

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Then open `http://localhost:8000` in your browser to access FicheNum.
 - **Proprietary AI (FicheGPT)** – analyzes and condenses information with high precision.
 - **Automatic assets** – generates text summaries, infographics, audio and quizzes.
 - **Universal sharing** – each sheet comes with a QR code and a direct link ready to distribute.
+- **Single-word categories** – each generated sheet is tagged with a concise one-word category.
 
 FicheNum aims to simplify content digestion for students, teachers and professionals alike. Feel free to adapt the code to your own needs.
 

--- a/create_fiche.php
+++ b/create_fiche.php
@@ -99,13 +99,13 @@ Tu es un expert en pédagogie et en écriture de contenus éducatifs. L'utilisat
 
 Génère une fiche professionnelle ultra complète avec ces éléments :
 1. Un **titre pertinent et vendeur** (en majuscules)
-2. Une **catégorie** adaptée au sujet (ex: Cuisine, Physique, Productivité...)
+2. Une **catégorie** adaptée au sujet en **un seul mot** (ex: Cuisine, Physique, Productivité...)
 3. Un **contenu pédagogique** complet sous forme de mini-ebook en Markdown, structuré en chapitres avec astuce, checklist, résumé, etc.
 
 Réponds uniquement dans ce format :
 ---
 TITLE: <titre en majuscule sans balise>
-CATEGORY: <catégorie sans balise>
+CATEGORY: <catégorie en un mot sans balise>
 FICHE:
 <fichier markdown sans balise code>
 ---
@@ -133,9 +133,11 @@ EOT;
     $content = $result['choices'][0]['message']['content'] ?? '';
 
     if (preg_match('/TITLE: (.+?)\nCATEGORY: (.+?)\nFICHE:\n(.+)/s', $content, $matches)) {
+        $cat = trim($matches[2]);
+        $cat = preg_split('/\s+/', $cat)[0]; // un seul mot maximum
         return [
             'title' => trim($matches[1]),
-            'category' => trim($matches[2]),
+            'category' => $cat,
             'fiche' => trim($matches[3])
         ];
     }


### PR DESCRIPTION
## Summary
- clarify the prompt so categories must be single words
- trim OpenAI response to keep only the first token
- document single-word category behavior in the README

## Testing
- `php -l create_fiche.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487d4f1bc0832498f6187768d08997