### PR TITLE
Allow HTML messages in fiche creation

### DIFF
--- a/create_fiche.php
+++ b/create_fiche.php
@@ -252,7 +252,7 @@ EOT;
   <h1 class="mb-4">Créer une fiche</h1>
 
   <?php if (!empty($message)): ?>
-    <div class="alert alert-warning"><?= htmlspecialchars($message) ?></div>
+    <div class="alert alert-warning"><?= $message ?></div>
   <?php endif; ?>
 
   <form method="post" id="fiche-form">


### PR DESCRIPTION
## Summary
- do not escape generated informational messages in `create_fiche.php`

## Testing
- `php -l create_fiche.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b03cbd0948324a4f104137d2e934e